### PR TITLE
fix: tiny translation error for Catalan

### DIFF
--- a/share/locale/musescore_ca.ts
+++ b/share/locale/musescore_ca.ts
@@ -8983,7 +8983,7 @@ l&apos;alçària x del text):</translation>
     <message>
         <location filename="../../src/notation/internal/notationuiactions.cpp" line="1243"/>
         <source>Add tied note to chord</source>
-        <translation>Afegeix la nota amb punt a l&apos;acord</translation>
+        <translation>Afegeix una nota lligada a l&apos;acord</translation>
     </message>
     <message>
         <location filename="../../src/notation/internal/notationuiactions.cpp" line="2394"/>


### PR DESCRIPTION
The catalan version showed "add tied note to chord" (I've seen it in the shortcuts menu) as if it was something along the lines of "add dotted note to chord". I fixed it by picking from the properly translated "add tied note" sentence, and just added the catalan equivalent of "to the chord" to it.

Resolves: (a new, small issue I found)

<!-- Add a short description of and motivation for the changes here -->
I got confused by the UI text when using the app, then researched here in the translation file and found out the confusion was due to a translation mistake. Since it's a small and non intrusive change, I thought I'd do it myself.



<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
